### PR TITLE
GitHub Actions: Add script to compress image.

### DIFF
--- a/.github/workflows/compress-image.yml
+++ b/.github/workflows/compress-image.yml
@@ -1,0 +1,37 @@
+name: Compress Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Following file extensions are supported.
+      - "**.jpg"
+      - "**.jpeg"
+      - "**.png"
+      - "**.webp"
+
+jobs:
+  build:
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+
+      - name: Compress Images
+        id: calibre
+        uses: calibreapp/image-actions@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          compressOnly: true
+
+      - name: Create Pull Request
+        # Open a PR, iff, there are new changes.
+        if: steps.calibre.outputs.markdown != ''
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Auto Compressed Images
+          branch-suffix: timestamp
+          commit-message: Compress Images
+          body: ${{ steps.calibre.outputs.markdown }}


### PR DESCRIPTION
## Please, go through these steps before you submit a PR.

- [x] My Pod Leader knows I'm working on this Pull Request
- [x] I've explained what the Pull Request is adding.
- [x] I've explained why this is important.


Using GitHub Actions, we can now compress images.
We use `image-actions` (https://github.com/calibreapp/image-actions)
to achieve the same. This helps to improve the
loading time for images.

GitHub Bot creates a new PR for the compressed
images, if there is any, whenever we push changes
to the `main` branch.

Fixes: #2.

